### PR TITLE
Update links to reference shakacode repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Greg Myers
+Copyright (c) 2023 ShakaCode, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ This repo contains two trees, one Webpacker and one Sprockets.
 
 Each branch illustrates a react-rails ability.
 
-* [`master`](https://github.com/BookOfGreg/react-rails-example-app) -> Webpacker 3
-* [`sprockets`](https://github.com/BookOfGreg/react-rails-example-app/tree/sprockets) -> Sprockets 3
-* [`rails-production-version`](https://github.com/BookOfGreg/react-rails-example-app/compare/sprockets...rails-production-version?expand=1) -> Sprockets 3 + serving production prebundled react
-* [`rails-assets-sprockets`](https://github.com/BookOfGreg/react-rails-example-app/compare/sprockets...rails-assets-sprockets?expand=1) -> Sprockets 3 + using Rails-Assets.org (failed)
-* [`generate-new-component`](https://github.com/BookOfGreg/react-rails-example-app/compare/master...generate-new-component?expand=1) -> Webpacker 3 + new style component
-* [`without-ujs`](https://github.com/BookOfGreg/react-rails-example-app/compare/master...without-ujs?expand=1) -> Sprockets 3 + removing UJS and making component globally accessible
-* [`jsx-file-example`](https://github.com/BookOfGreg/react-rails-example-app/compare/master...jsx-file-example?expand=1) -> Webpacker 3 + file named .JSX
-* [`coffeescript-example`](https://github.com/BookOfGreg/react-rails-example-app/compare/master...coffeescript-example?expand=1) -> Webpacker 3 + Coffeescript WITH JSX
+* [`master`](https://github.com/shakacode/react-rails-example-app) -> Webpacker 3
+* [`sprockets`](https://github.com/shakacode/react-rails-example-app/tree/sprockets) -> Sprockets 3
+* [`rails-production-version`](https://github.com/shakacode/react-rails-example-app/compare/sprockets...rails-production-version?expand=1) -> Sprockets 3 + serving production prebundled react
+* [`rails-assets-sprockets`](https://github.com/shakacode/react-rails-example-app/compare/sprockets...rails-assets-sprockets?expand=1) -> Sprockets 3 + using Rails-Assets.org (failed)
+* [`generate-new-component`](https://github.com/shakacode/react-rails-example-app/compare/master...generate-new-component?expand=1) -> Webpacker 3 + new style component
+* [`without-ujs`](https://github.com/shakacode/react-rails-example-app/compare/master...without-ujs?expand=1) -> Sprockets 3 + removing UJS and making component globally accessible
+* [`jsx-file-example`](https://github.com/shakacode/react-rails-example-app/compare/master...jsx-file-example?expand=1) -> Webpacker 3 + file named .JSX
+* [`coffeescript-example`](https://github.com/shakacode/react-rails-example-app/compare/master...coffeescript-example?expand=1) -> Webpacker 3 + Coffeescript WITH JSX


### PR DESCRIPTION
In this PR, links to different branches on BookOfGreg are replaced with Shakacode (this) repo.
Also, a new line for copyright notice is added to the License file.